### PR TITLE
feat: add JSON output and CI fail thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Open-source backup readiness checker for self-hosted Docker Compose stacks.
 
-BackupProof scans a `docker-compose.yml` file and prints a Markdown report about persistent services, database volumes, missing backup hints, and missing restore-test signals. It is built for self-hosters, homelab users, small teams, and developers running apps on a VPS, NAS, home server, Tailscale, WireGuard, or a reverse proxy.
+BackupProof scans a `docker-compose.yml` file and prints a Markdown or JSON report about persistent services, database volumes, missing backup hints, and missing restore-test signals. It is built for self-hosters, homelab users, small teams, and developers running apps on a VPS, NAS, home server, Tailscale, WireGuard, or a reverse proxy.
 
 BackupProof is a lightweight readiness review tool. It does not guarantee recoverability, run backups, run restores, connect to containers, or replace a real restore test.
 
@@ -54,12 +54,94 @@ After installing from npm in the future, the intended command is:
 backupproof scan ./docker-compose.yml --format markdown
 ```
 
+Markdown is the default output format:
+
+```bash
+node dist/cli.js scan ./docker-compose.yml
+```
+
+## JSON Output
+
+Use JSON when you want machine-readable output for CI, scripts, or dashboards you build yourself:
+
+```bash
+node dist/cli.js scan ./docker-compose.yml --format json
+```
+
+The JSON report includes tool metadata, the scanned file path, finding counts by severity, persistent volume counts, database-like service counts, backup hints, restore-test hints, persistent services, volumes, and findings.
+
+## CI Fail Thresholds
+
+Use `--fail-on` to make BackupProof return a failing exit code when findings meet or exceed a severity threshold:
+
+```bash
+node dist/cli.js scan ./docker-compose.yml --fail-on high
+node dist/cli.js scan ./docker-compose.yml --format json --fail-on medium
+```
+
+Allowed values:
+
+- `none` - always exit `0`; this is the default for backward compatibility
+- `high` - exit `1` if any high finding exists
+- `medium` - exit `1` if any medium or high finding exists
+- `low` - exit `1` if any low, medium, or high finding exists
+
+Exit codes:
+
+- `0` - scan completed and the selected threshold was not violated
+- `1` - scan completed and the selected `--fail-on` threshold was violated
+- `2` - invalid CLI usage or file parsing error
+
 ## Run With Docker
 
 ```bash
 docker build -t backupproof .
 docker run --rm -v $(pwd):/scan backupproof scan /scan/docker-compose.yml --format markdown
 ```
+
+Docker with JSON output:
+
+```bash
+docker run --rm -v $(pwd):/scan backupproof scan /scan/docker-compose.yml --format json
+```
+
+Docker with CI threshold:
+
+```bash
+docker run --rm -v $(pwd):/scan backupproof scan /scan/docker-compose.yml --format json --fail-on high
+```
+
+## GitHub Actions
+
+BackupProof can run in CI without contacting your containers or sending Compose files anywhere.
+
+Minimal example:
+
+```yaml
+name: BackupProof
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  backupproof:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node dist/cli.js scan examples/risky-compose.yml --format markdown --fail-on high
+      - run: node dist/cli.js scan examples/risky-compose.yml --format json
+```
+
+See [docs/ci-usage.md](docs/ci-usage.md) and [docs/github-actions-example.yml](docs/github-actions-example.yml).
 
 ## Example Report
 
@@ -94,9 +176,7 @@ See [examples/report.md](examples/report.md) for a generated example.
 
 ## Roadmap
 
-- JSON report output
 - HTML report output
-- GitHub Actions integration
 - Better backup tool detection
 - Restore-test reminder templates
 - Backup schedule detection

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -1,0 +1,123 @@
+# CI Usage
+
+BackupProof is a local, read-only backup readiness review tool for Docker Compose stacks. It does not run backups, run restore tests, connect to containers, modify Compose files, or send Compose files and reports anywhere.
+
+Use CI to make backup readiness drift visible during pull requests.
+
+## Local Usage
+
+```bash
+npm install
+npm run build
+node dist/cli.js scan ./docker-compose.yml --format markdown
+```
+
+Markdown is the default:
+
+```bash
+node dist/cli.js scan ./docker-compose.yml
+```
+
+## Docker Usage
+
+```bash
+docker build -t backupproof .
+docker run --rm -v $(pwd):/scan backupproof scan /scan/docker-compose.yml --format markdown
+```
+
+JSON output with Docker:
+
+```bash
+docker run --rm -v $(pwd):/scan backupproof scan /scan/docker-compose.yml --format json
+```
+
+## JSON Output
+
+Use JSON when another tool needs to read the report:
+
+```bash
+node dist/cli.js scan ./docker-compose.yml --format json
+```
+
+The JSON report includes:
+
+- tool name and version
+- scanned file path
+- generated timestamp
+- finding counts by severity
+- persistent volume count
+- database-like service count
+- backup and restore-test hint counts
+- persistent services
+- volumes
+- backup hints
+- restore-test hints
+- findings
+
+## Fail-On Thresholds
+
+Use `--fail-on` to make CI fail when findings meet or exceed a selected severity:
+
+```bash
+node dist/cli.js scan ./docker-compose.yml --fail-on high
+node dist/cli.js scan ./docker-compose.yml --format json --fail-on medium
+```
+
+Allowed values:
+
+- `none` - always exit `0`; default
+- `high` - exit `1` if any high finding exists
+- `medium` - exit `1` if any medium or high finding exists
+- `low` - exit `1` if any low, medium, or high finding exists
+
+Exit codes:
+
+- `0` - scan completed and the selected threshold was not violated
+- `1` - scan completed and the selected threshold was violated
+- `2` - invalid CLI usage or file parsing error
+
+## GitHub Actions Example
+
+See [github-actions-example.yml](github-actions-example.yml).
+
+```yaml
+name: BackupProof
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  backupproof:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node dist/cli.js scan examples/risky-compose.yml --format markdown --fail-on high
+      - run: node dist/cli.js scan examples/risky-compose.yml --format json
+```
+
+## Recommended Usage
+
+For self-hosted projects, start with:
+
+```bash
+node dist/cli.js scan docker-compose.yml --format markdown --fail-on high
+```
+
+This fails CI only for high-risk findings, which keeps the signal useful while you tune backup labels, backup services, and restore-test documentation.
+
+Once the project is cleaner, consider:
+
+```bash
+node dist/cli.js scan docker-compose.yml --format json --fail-on medium
+```
+
+Do not treat a passing BackupProof scan as proof that backups are recoverable. Run real restore tests and keep recovery steps documented.

--- a/docs/github-actions-example.yml
+++ b/docs/github-actions-example.yml
@@ -1,0 +1,32 @@
+name: BackupProof
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  backupproof:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build BackupProof
+        run: npm run build
+
+      - name: Run Markdown backup readiness check
+        run: node dist/cli.js scan examples/risky-compose.yml --format markdown --fail-on high
+
+      - name: Generate JSON report
+        run: node dist/cli.js scan examples/risky-compose.yml --format json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backupproof",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backupproof",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "commander": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backupproof",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Open-source backup readiness checker for self-hosted Docker Compose stacks",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,31 +1,40 @@
 #!/usr/bin/env node
 import { Command } from "commander";
-import { renderMarkdownReport, scanComposeFile } from "./index.js";
+import { parseFailOnThreshold, shouldFailOnThreshold } from "./failOn.js";
+import { renderJsonReport, renderMarkdownReport, scanComposeFile } from "./index.js";
 
 const program = new Command();
+const EXIT_USAGE_OR_PARSE_ERROR = 2;
 
 program
   .name("backupproof")
   .description("Backup readiness checker for self-hosted Docker Compose stacks")
-  .version("0.1.0");
+  .version("0.2.0");
 
 program
   .command("scan")
   .description("Scan a docker-compose.yml file")
   .argument("<file>", "Path to docker-compose.yml")
-  .option("-f, --format <format>", "Report format: markdown", "markdown")
-  .action(async (file: string, options: { format: string }) => {
+  .option("-f, --format <format>", "Report format: markdown or json", "markdown")
+  .option("--fail-on <severity>", "Exit 1 when findings at or above severity exist: high, medium, low, none", "none")
+  .action(async (file: string, options: { format: string; failOn: string }) => {
     try {
-      if (options.format !== "markdown") {
-        throw new Error(`Unsupported format: ${options.format}. The MVP supports markdown only.`);
+      if (options.format !== "markdown" && options.format !== "json") {
+        throw new Error(`Unsupported format: ${options.format}. Allowed values are markdown, json.`);
       }
 
+      const failOn = parseFailOnThreshold(options.failOn);
       const result = await scanComposeFile(file);
-      process.stdout.write(`${renderMarkdownReport(result)}\n`);
+      const report = options.format === "json" ? renderJsonReport(result) : `${renderMarkdownReport(result)}\n`;
+      process.stdout.write(report);
+
+      if (shouldFailOnThreshold(result.findings, failOn)) {
+        process.exitCode = 1;
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       process.stderr.write(`BackupProof scan failed: ${message}\n`);
-      process.exitCode = 1;
+      process.exitCode = EXIT_USAGE_OR_PARSE_ERROR;
     }
   });
 

--- a/src/failOn.ts
+++ b/src/failOn.ts
@@ -1,0 +1,26 @@
+import type { Finding, Severity } from "./types.js";
+
+export type FailOnThreshold = Severity | "none";
+
+const severityRank: Record<Severity, number> = {
+  high: 3,
+  medium: 2,
+  low: 1
+};
+
+export function parseFailOnThreshold(value: string): FailOnThreshold {
+  if (value === "high" || value === "medium" || value === "low" || value === "none") {
+    return value;
+  }
+
+  throw new Error(`Invalid --fail-on value: ${value}. Allowed values are high, medium, low, none.`);
+}
+
+export function shouldFailOnThreshold(findings: Finding[], threshold: FailOnThreshold): boolean {
+  if (threshold === "none") {
+    return false;
+  }
+
+  const minimumRank = severityRank[threshold];
+  return findings.some((finding) => severityRank[finding.severity] >= minimumRank);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { parseComposeFile } from "./parser.js";
+import { renderJsonReport } from "./report/json.js";
 import { renderMarkdownReport } from "./report/markdown.js";
 import { backupHintsRule } from "./rules/backupHints.js";
 import { backupServicesRule } from "./rules/backupServices.js";
@@ -114,7 +115,7 @@ export function scanCompose(compose: ComposeFile, filePath = "docker-compose.yml
   };
 }
 
-export { renderMarkdownReport };
+export { renderJsonReport, renderMarkdownReport };
 
 export function analyzeCompose(compose: ComposeFile, filePath: string): ScanContext {
   const services = Object.entries(compose.services).map(([name, service]) => analyzeService(name, service));

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { Finding, Hint, MountedVolume, ScanResult, ServiceAnalysis, Severity } from "../types.js";
+
+interface PackageJson {
+  version?: string;
+}
+
+export interface JsonReport {
+  tool: "BackupProof";
+  version: string;
+  scannedFile: string;
+  generatedAt: string;
+  summary: {
+    totalFindings: number;
+    high: number;
+    medium: number;
+    low: number;
+    persistentVolumes: number;
+    databaseLikeServices: number;
+    backupHints: number;
+    restoreTestHints: number;
+  };
+  persistentServices: Array<{
+    name: string;
+    image?: string;
+    isDatabaseLike: boolean;
+    persistentMounts: MountedVolume[];
+  }>;
+  volumes: MountedVolume[];
+  backupHints: Hint[];
+  restoreHints: Hint[];
+  findings: Finding[];
+}
+
+const severities: Severity[] = ["high", "medium", "low"];
+
+export function renderJsonReport(result: ScanResult, generatedAt = new Date()): string {
+  return `${JSON.stringify(createJsonReport(result, generatedAt), null, 2)}\n`;
+}
+
+export function createJsonReport(result: ScanResult, generatedAt = new Date()): JsonReport {
+  return {
+    tool: "BackupProof",
+    version: getPackageVersion(),
+    scannedFile: result.filePath,
+    generatedAt: generatedAt.toISOString(),
+    summary: {
+      totalFindings: result.findings.length,
+      high: countFindings(result.findings, "high"),
+      medium: countFindings(result.findings, "medium"),
+      low: countFindings(result.findings, "low"),
+      persistentVolumes: result.persistentVolumes.length,
+      databaseLikeServices: result.services.filter((service) => service.isDatabaseLike).length,
+      backupHints: result.backupHints.length,
+      restoreTestHints: result.restoreHints.length
+    },
+    persistentServices: result.persistentServices.map(toPersistentServiceJson),
+    volumes: result.volumes,
+    backupHints: result.backupHints,
+    restoreHints: result.restoreHints,
+    findings: result.findings
+  };
+}
+
+function countFindings(findings: Finding[], severity: Severity): number {
+  return findings.filter((finding) => finding.severity === severity).length;
+}
+
+function toPersistentServiceJson(service: ServiceAnalysis): JsonReport["persistentServices"][number] {
+  return {
+    name: service.name,
+    image: service.image,
+    isDatabaseLike: service.isDatabaseLike,
+    persistentMounts: service.persistentMounts
+  };
+}
+
+function getPackageVersion(): string {
+  try {
+    const packageJsonPath = fileURLToPath(new URL("../../package.json", import.meta.url));
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as PackageJson;
+    return packageJson.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}

--- a/tests/failOn.test.ts
+++ b/tests/failOn.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { parseFailOnThreshold, shouldFailOnThreshold } from "../src/failOn.js";
+import type { Finding } from "../src/types.js";
+
+const findings: Finding[] = [
+  {
+    ruleId: "HIGH_RULE",
+    severity: "high",
+    service: "db",
+    title: "High finding",
+    description: "High finding",
+    evidence: "db_data:/data",
+    recommendation: "Fix it"
+  },
+  {
+    ruleId: "MEDIUM_RULE",
+    severity: "medium",
+    service: "app",
+    title: "Medium finding",
+    description: "Medium finding",
+    evidence: "./data:/data",
+    recommendation: "Fix it"
+  },
+  {
+    ruleId: "LOW_RULE",
+    severity: "low",
+    service: "cache",
+    title: "Low finding",
+    description: "Low finding",
+    evidence: "cache_data:/data",
+    recommendation: "Review it"
+  }
+];
+
+describe("--fail-on threshold handling", () => {
+  it("parses supported threshold values", () => {
+    expect(parseFailOnThreshold("high")).toBe("high");
+    expect(parseFailOnThreshold("medium")).toBe("medium");
+    expect(parseFailOnThreshold("low")).toBe("low");
+    expect(parseFailOnThreshold("none")).toBe("none");
+  });
+
+  it("rejects unsupported threshold values", () => {
+    expect(() => parseFailOnThreshold("critical")).toThrow("Invalid --fail-on value");
+  });
+
+  it("fails only when findings meet or exceed the selected threshold", () => {
+    expect(shouldFailOnThreshold(findings, "none")).toBe(false);
+    expect(shouldFailOnThreshold(findings, "high")).toBe(true);
+    expect(shouldFailOnThreshold(findings, "medium")).toBe(true);
+    expect(shouldFailOnThreshold(findings, "low")).toBe(true);
+    expect(shouldFailOnThreshold([findings[1], findings[2]], "high")).toBe(false);
+    expect(shouldFailOnThreshold([findings[2]], "medium")).toBe(false);
+    expect(shouldFailOnThreshold([findings[2]], "low")).toBe(true);
+  });
+});

--- a/tests/jsonReport.test.ts
+++ b/tests/jsonReport.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { scanCompose } from "../src/index.js";
+import { parseComposeContent } from "../src/parser.js";
+import { createJsonReport, renderJsonReport } from "../src/report/json.js";
+
+describe("JSON report output", () => {
+  it("renders summary, hints, volumes, persistent services, and findings", () => {
+    const compose = parseComposeContent(`
+services:
+  db:
+    image: postgres:16
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  restic:
+    image: restic/restic
+    command: backup /postgres-data
+    labels:
+      restore-test: "quarterly verification"
+    volumes:
+      - db_data:/postgres-data:ro
+volumes:
+  db_data:
+`);
+
+    const result = scanCompose(compose, "docker-compose.yml");
+    const report = createJsonReport(result, new Date("2026-04-28T00:00:00.000Z"));
+
+    expect(report.tool).toBe("BackupProof");
+    expect(report.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(report.scannedFile).toBe("docker-compose.yml");
+    expect(report.generatedAt).toBe("2026-04-28T00:00:00.000Z");
+    expect(report.summary).toMatchObject({
+      totalFindings: result.findings.length,
+      high: 0,
+      medium: 0,
+      low: 2,
+      persistentVolumes: 1,
+      databaseLikeServices: 1,
+      backupHints: 3,
+      restoreTestHints: 3
+    });
+    expect(report.persistentServices).toHaveLength(1);
+    expect(report.persistentServices[0]).toMatchObject({
+      name: "db",
+      image: "postgres:16",
+      isDatabaseLike: true
+    });
+    expect(report.volumes).toHaveLength(2);
+    expect(report.backupHints.map((hint) => hint.keyword)).toEqual(["restic", "restic", "backup"]);
+    expect(report.restoreHints.map((hint) => hint.keyword)).toEqual(["restore", "restore-test", "verification"]);
+    expect(report.findings[0]).toEqual(
+      expect.objectContaining({
+        ruleId: "PERSISTENT_NAMED_VOLUME_DETECTED",
+        severity: "low",
+        service: "db"
+      })
+    );
+  });
+
+  it("returns parseable pretty JSON with a trailing newline", () => {
+    const compose = parseComposeContent(`
+services:
+  app:
+    image: example/app
+`);
+
+    const result = scanCompose(compose, "compose.yml");
+    const json = renderJsonReport(result, new Date("2026-04-28T00:00:00.000Z"));
+
+    expect(json.endsWith("\n")).toBe(true);
+    expect(JSON.parse(json)).toMatchObject({
+      tool: "BackupProof",
+      scannedFile: "compose.yml",
+      generatedAt: "2026-04-28T00:00:00.000Z"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds CI-ready reporting and failure behavior for BackupProof.

- Adds JSON report output with tool metadata, summary counts, persistent services, volumes, hints, and findings
- Adds `--fail-on <severity>` thresholds for CI
- Adds deterministic exit codes for success, threshold failures, and usage/parsing errors
- Adds GitHub Actions usage documentation and an example workflow file
- Updates README usage for JSON, CI thresholds, Docker, and exit codes

## New CLI options

```bash
backupproof scan docker-compose.yml --format json
backupproof scan docker-compose.yml --fail-on high
backupproof scan docker-compose.yml --format json --fail-on medium
```

Allowed `--fail-on` values:

- `none`
- `high`
- `medium`
- `low`

Exit codes:

- `0` when no threshold is violated
- `1` when the selected threshold is violated
- `2` for invalid CLI usage or file parsing errors

## Tests run

```bash
npm install
npm test
npm run build
node dist/cli.js scan examples/risky-compose.yml --format markdown
node dist/cli.js scan examples/risky-compose.yml --format json
node dist/cli.js scan examples/risky-compose.yml --fail-on high
node dist/cli.js scan examples/risky-compose.yml --fail-on none
node dist/cli.js scan examples/risky-compose.yml --format xml
node dist/cli.js scan examples/missing.yml --format json
node dist/cli.js scan examples/risky-compose.yml --fail-on critical
npm audit
```

## Docker command tested

```bash
docker build -t backupproof .
docker run --rm -v $(pwd):/scan backupproof scan /scan/examples/risky-compose.yml --format json
```

## Current limitations

- BackupProof remains read-only
- It does not run backups
- It does not run restore tests
- It does not connect to containers
- It does not guarantee recoverability
- It is still heuristic and not a complete disaster recovery audit