### PR TITLE
docs: add paid path entrypoints

### DIFF
--- a/.github/ISSUE_TEMPLATE/early_access_request.md
+++ b/.github/ISSUE_TEMPLATE/early_access_request.md
@@ -1,0 +1,37 @@
+---
+name: Early Access Request
+about: Register interest in a future SelfHostGuard hosted dashboard
+title: "Early access request: "
+labels: question
+assignees: ""
+---
+
+## Safety note
+
+Do not paste secrets, credentials, private compose files, or sensitive infrastructure details.
+
+## What are you running?
+
+
+## How many Docker Compose stacks do you manage?
+
+
+## What backup tools do you use?
+
+
+## Do you need scheduled backup readiness scans?
+
+
+## Do you need restore-test reminders?
+
+
+## Do you need Slack / Discord alerts?
+
+
+## Are you interested in a hosted dashboard?
+
+
+## Is this for personal, homelab, team, or company use?
+
+
+## Contact method, optional

--- a/.github/ISSUE_TEMPLATE/setup_review_request.md
+++ b/.github/ISSUE_TEMPLATE/setup_review_request.md
@@ -1,0 +1,42 @@
+---
+name: Setup Review Request
+about: Request interest for a paid backup or restore readiness setup review
+title: "Setup review request: "
+labels: question
+assignees: ""
+---
+
+## Safety note
+
+Do not paste secrets, credentials, private compose files, or sensitive infrastructure details.
+
+## What kind of backup setup do you want reviewed?
+
+
+## Main concern
+
+Choose any that apply:
+
+- missing backups
+- database backups
+- restore tests
+- offsite backups
+- backup coverage
+- other
+
+## Approximate number of services
+
+
+## Backup tools currently used, if any
+
+
+## Docker Compose snippet, without secrets, optional
+
+```yaml
+
+```
+
+## Preferred contact method, optional
+
+
+## Urgency, optional

--- a/README.md
+++ b/README.md
@@ -193,9 +193,26 @@ Start with [CONTRIBUTING.md](CONTRIBUTING.md). Useful contributions include new 
 
 For now, use GitHub Issues and Discussions if enabled. Please avoid posting secrets, private hostnames, tokens, passwords, or complete production Compose files in public issues.
 
-## Hosted Version / Support Note
+## Hosted dashboard / paid support
 
-Hosted dashboards, scheduled backup readiness scans, alerts, and setup reviews may come later. If you are interested, open an issue or contact the maintainer.
+BackupProof is free and open source.
+
+A hosted SelfHostGuard dashboard may come later for teams that want:
+
+- scheduled backup readiness scans
+- scan history
+- restore-test reminders
+- backup risk diffs over time
+- GitHub Actions integration
+- Slack / Discord alerts
+- multi-stack monitoring
+- team reports
+
+This dashboard does not exist yet, and BackupProof still does not run backups, run restore tests, or guarantee recoverability. Real restore tests are still required.
+
+If you want early access, open an [Early Access Request](https://github.com/kozinkaihatusya/backupproof/issues/new?template=early_access_request.md).
+
+If you need help reviewing your self-hosted backup setup, open a [Setup Review Request](https://github.com/kozinkaihatusya/backupproof/issues/new?template=setup_review_request.md).
 
 ## License
 

--- a/docs/paid-support.md
+++ b/docs/paid-support.md
@@ -1,0 +1,48 @@
+# Paid Support And Early Access
+
+BackupProof CLI is free and open source.
+
+The hosted SelfHostGuard dashboard is not available yet. This document is only for collecting interest and setting expectations for possible future paid paths.
+
+BackupProof remains read-only. It does not run backups, run restore tests, connect to containers, modify Compose files, or guarantee recoverability. Real restore tests are still required.
+
+## Possible Hosted Dashboard
+
+A future SelfHostGuard hosted dashboard may include:
+
+- scheduled backup readiness scans
+- scan history
+- restore-test reminders
+- diff reports
+- alerts
+- GitHub Actions integration
+- multi-stack monitoring
+- team reports
+
+If this would be useful, open an Early Access Request:
+
+https://github.com/kozinkaihatusya/backupproof/issues/new?template=early_access_request.md
+
+## Possible Paid Setup Review
+
+Paid backup readiness or restore readiness setup reviews may be considered later.
+
+A review could include:
+
+- backup coverage review
+- database backup review
+- volume coverage review
+- restore-test readiness review
+- written report
+
+This is not guaranteed support, and there is no fixed pricing yet. The current goal is to understand what users need before building anything hosted or paid.
+
+If you want to request interest in a review, open a Setup Review Request:
+
+https://github.com/kozinkaihatusya/backupproof/issues/new?template=setup_review_request.md
+
+## Enterprise Or Self-Hosting Support
+
+Enterprise and self-hosting support may be considered later for teams running multiple Compose stacks or needing internal reporting.
+
+No enterprise product is available yet. If this matters to your team, open an issue with the use case and avoid sharing sensitive infrastructure details.

--- a/launch/devto-article.md
+++ b/launch/devto-article.md
@@ -109,6 +109,12 @@ It runs locally. It does not upload Compose files, connect to containers, run ba
 
 It also does not guarantee recoverability. It is a lightweight readiness review tool, not a replacement for a real restore test.
 
+## What might come next
+
+If the CLI proves useful, I may explore SelfHostGuard as a hosted dashboard for scheduled scans, restore-test reminders, scan history, backup risk changes over time, and alerts.
+
+That does not exist yet. The CLI is still free and open source, and real restore tests are still required.
+
 ## GitHub link
 
 GitHub:

--- a/launch/hacker-news.md
+++ b/launch/hacker-news.md
@@ -21,4 +21,6 @@ It is built for self-hosters, homelab users, and small teams running Compose on 
 
 The tool runs locally. It does not send Compose files anywhere, connect to containers, run backups, or run restores. It is intentionally just a lightweight review tool, not a guarantee that backups are correct.
 
+I am also collecting interest in a possible hosted SelfHostGuard dashboard later, but the CLI is the main thing today and remains free/open source.
+
 The MVP is TypeScript, a CLI, and Docker-friendly. Feedback on false positives, missing backup tools, and real-world Compose patterns would be very welcome.

--- a/launch/reddit-selfhosted.md
+++ b/launch/reddit-selfhosted.md
@@ -29,4 +29,6 @@ docker run --rm -v $(pwd):/scan backupproof scan /scan/docker-compose.yml --form
 
 It does not run backups, run restores, connect to containers, or upload Compose files anywhere. It is just a read-only sanity check. It also does not replace a real restore test.
 
+I'm also collecting interest for a hosted SelfHostGuard dashboard and backup setup reviews, but the CLI itself is free and open source.
+
 I would appreciate feedback from people with real self-hosted Compose setups, especially examples where the heuristic gets something wrong or misses a common backup pattern. If it seems useful, a GitHub star also helps other self-hosters find it, but feedback is more useful right now.


### PR DESCRIPTION
## Summary

Adds repository-level entrypoints for future paid paths without implementing any paid, hosted, auth, cloud, backup, or restore functionality.

- Adds README links for SelfHostGuard early access and setup review requests
- Adds GitHub issue templates for early access and setup review requests
- Adds docs explaining possible paid support and future hosted dashboard interest collection
- Adds light notes to selected launch drafts while keeping GitHub feedback as the main CTA

## Files changed

- `README.md`
- `.github/ISSUE_TEMPLATE/early_access_request.md`
- `.github/ISSUE_TEMPLATE/setup_review_request.md`
- `docs/paid-support.md`
- `launch/reddit-selfhosted.md`
- `launch/hacker-news.md`
- `launch/devto-article.md`

## Tests run

```bash
npm install
npm test
npm run build
docker build -t backupproof .
```

## What this does not implement

- No hosted dashboard
- No payments
- No authentication
- No cloud functionality
- No new product features
- No backup execution
- No restore-test execution
- No external posting

## Manual follow-up

- Review inbound Early Access Request and Setup Review Request issues manually.
- Decide later whether SelfHostGuard Cloud or paid review services should actually be built.